### PR TITLE
Overcome python version issues another way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ bundle-deps:
 	echo "Checking if ${BUILD_DEPS} exists..." && \
 	if [[ ! -d ${BUILD_DEPS} ]]; then \
 		mkdir -p ${BUILD_DEPS} && \
-		pip install -r portal-cdk/lambda/requirements.txt -t ${BUILD_DEPS} ; \
+		pip install -r portal-cdk/lambda/requirements.txt --platform manylinux2014_x86_64 --only-binary=:all: -t ${BUILD_DEPS} ; \
 	else \
 		echo "Skipping deps bundled in ${BUILD_DEPS}. Remove to rebuild."; \
 	fi

--- a/portal-cdk/lambda/requirements.txt
+++ b/portal-cdk/lambda/requirements.txt
@@ -1,9 +1,7 @@
+# The build Makefile should build this requirements.txt with the right settings.
+# https://stackoverflow.com/a/74729344 
+
 jinja2==3.1.6
 
 # To interact with the SSO Token
 opensarlab-backend==1.0.4
-
-# To overcome a versioning error with the lambda and opensarlab-backend
-# https://stackoverflow.com/a/77792618 
-bcrypt==3.2.2
-cryptography==3.4.8


### PR DESCRIPTION
If the pip wheels are not built for Amazon Linux (as used in the lambda) then they could fail to work properly. In particular, the `cryptography` module wasn't working properly so the version was forcefully downgraded. However, Dependabot has recognized some serious vulnerabilities like "Python Cryptography package vulnerable to Bleichenbacher timing oracle attack". Therefore another solution needed to be found that allowed for the latest module versions without the lambda issues. Building to the platform type seems to work well enough.