### PR TITLE
redirect from logout to home page

### DIFF
--- a/portal-cdk/lambda/main.py
+++ b/portal-cdk/lambda/main.py
@@ -54,12 +54,9 @@ def root():
 @app.get("/logout")
 def logout():
     return wrap_response(
-        render_template(
-            content="You have been logged out",
-            title="Logged Out",
-            name="logged-out.j2",
-        ),
-        code=200,
+        body="You have been logged out",
+        headers={"Location": "/"},
+        code=302,
         cookies=delete_cookies(),
     )
 

--- a/portal-cdk/lambda/tests/util/test_auth.py
+++ b/portal-cdk/lambda/tests/util/test_auth.py
@@ -206,10 +206,11 @@ class TestPortalAuth:
     def test_log_out(self, lambda_context, helpers):
         event = helpers.get_event(path="/logout")
         ret = main.lambda_handler(event, lambda_context)
-        assert ret["statusCode"] == 200
+        assert ret["statusCode"] == 302
         # Make sure we've been logged out
         assert ret["body"].find("You have been logged out") != -1
-        assert ret["body"].find('<span id="login_widget">') != -1
         # And cookies are being expired
         assert ret["cookies"][0].find("Expires") != -1
         assert ret["cookies"][1].find("Expires") != -1
+        # And user is redirected to home page
+        assert ret["headers"].get("Location") == "/"


### PR DESCRIPTION
`/logout` endpoint redirects to `/` instead of rendering new page