### PR TITLE
Broke up the profiles lists, to make it clear when one ends and another starts

### DIFF
--- a/portal-cdk/lambda_main/templates/manage.j2
+++ b/portal-cdk/lambda_main/templates/manage.j2
@@ -26,9 +26,9 @@
                 <th>
                     {% for profile in lab.allowed_profiles %}
                         {% if profile in user["labs"][lab.short_lab_name]["lab_profiles"] %}
-                            <span style="color: green;">{{ profile }}</span>
+                            <span style="border: 1px solid black; padding: 1px 4px; color: green;">{{ profile }}</span>,
                         {% else %}
-                            <span style="color: red;">{{ profile }}</span>
+                            <span style="border: 1px solid black; padding: 1px 4px; color: red;">{{ profile }}</span>,
                         {% endif %}
                     {% endfor %}
                 </th>

--- a/portal-cdk/lambda_main/templates/profile.j2
+++ b/portal-cdk/lambda_main/templates/profile.j2
@@ -322,9 +322,9 @@
                             {% if lab.short_lab_name in user_profile.labs %}
                                 {% for profile in lab.allowed_profiles %}
                                     {% if profile in user_profile.labs[lab.short_lab_name]["lab_profiles"] %}
-                                        <span style="color: green;">{{ profile }}</span>
+                                        <span style="border: 1px solid black; padding: 1px 4px; color: green;">{{ profile }}</span>,
                                     {% else %}
-                                        <span style="color: red;">{{ profile }}</span>
+                                        <span style="border: 1px solid black; padding: 1px 4px; color: red;">{{ profile }}</span>,
                                     {% endif %}
                                 {% endfor %}
                             {% elif user_profile.is_admin() %}


### PR DESCRIPTION
Profile - Admin Section:
<img width="1567" height="158" alt="image" src="https://github.com/user-attachments/assets/68858085-8829-471d-b38c-f2ef645b0357" />

Lab Manage Page:
<img width="1467" height="310" alt="image" src="https://github.com/user-attachments/assets/7e614a40-94e9-41ee-a002-083485f19b70" />

Also confirmed that with `Lab Manage`, you can copy-paste from the existing profiles. They're `,` separated.