### PR TITLE
[OSL-3843] add error page to S3 bucket cdk

### DIFF
--- a/portal-cdk/portal_cdk/portal_cdk_stack.py
+++ b/portal-cdk/portal_cdk/portal_cdk_stack.py
@@ -218,7 +218,7 @@ class PortalCdkStack(Stack):
                 cloudfront.ErrorResponse(
                     http_status=500,
                     response_page_path="/error.html",
-                    response_http_status=500,
+                    response_http_status=503,
                     ttl=Duration.minutes(5),
                 ),
                 cloudfront.ErrorResponse(


### PR DESCRIPTION
Adds all files in `portal-cdk/lambda_main/static/html` to an S3 bucket
all routing to paths matching `/error*.html` gets the file from the corresponding path in the S3 bucket
adds redirect for 503 errors to `/error.html`