### PR TITLE
fix: appropriatly log when users get added or modified

### DIFF
--- a/portal-cdk/lambda_main/portal/access.py
+++ b/portal-cdk/lambda_main/portal/access.py
@@ -225,7 +225,9 @@ def edit_user(shortname):
     user = User(body["username"])
 
     if body["action"] == "add_user":
-        update: bool = shortname in user.get_lab_access()["lab_access"].keys()
+        lab_access: bool = user.get_lab_access()["lab_access"].get(shortname, {})
+        update: bool = lab_access.get("can_user_access_lab", False)
+
         user.add_lab(
             lab_short_name=shortname,
             lab_profiles=[s.strip() for s in body["lab_profiles"].split(",")],


### PR DESCRIPTION
Currently, users don't get appropriately logged when being added to labs.

The current code block that determines how a user gets logged is

```python
update: bool = shortname in user.get_lab_access()["lab_access"].keys()
```

Where an admin (who can always see all labs) might have an example access request like this:

```python
{
    "viewable_labs_config": {
        "test_protected": BaseLabConfig(
            friendly_name="Test Protected Lab",
            short_lab_name="test_protected",
            accessibility="protected",
            allowed_profiles=[],
            deployment_url="",
            calendar_url=None,
            description="",
            logo="NASA_logo.svg",
            about_page_url=None,
            about_page_button_label=None,
            ip_country_status={"limited": [], "prohibited": ["KP", "SY", "IR"]},
            crypto_remediation_role_arn=None,
            default_profiles=["m6a.large", "m6a.xlarge"],
            application_questions=[
                {
                    "name": "why",
                    "question": "Why do you want access?",
                    "type": "text",
                    "rendering_options": "multi-line",
                    "placeholder": "Your Answer",
                }
            ],
            application_description=None,
            allows_tokens=False,
        ),
        "test_prohibited": BaseLabConfig(
            friendly_name="Test Prohibited Lab",
            short_lab_name="test_prohibited",
            accessibility="protected",
            allowed_profiles=[],
            deployment_url="",
            calendar_url=None,
            description="",
            logo="OpenSARLab_logo.png",
            about_page_url=None,
            about_page_button_label=None,
            ip_country_status={"limited": [], "prohibited": ["US"]},
            crypto_remediation_role_arn=None,
            default_profiles=["m6a.large", "m6a.xlarge"],
            application_questions=[],
            application_description=None,
            allows_tokens=False,
        ),
    },
    "lab_access": {
        "test_protected": {"can_user_see_lab": True, "can_user_access_lab": False},
        "test_prohibited": {"can_user_see_lab": True, "can_user_access_lab": False},
    },
}
```

A user with standard permissions and no special access would see

```python
{
    "viewable_labs_config": {
        "test_protected": BaseLabConfig(
            friendly_name="Test Protected Lab",
            short_lab_name="test_protected",
            accessibility="protected",
            allowed_profiles=[],
            deployment_url="",
            calendar_url=None,
            description="",
            logo="NASA_logo.svg",
            about_page_url=None,
            about_page_button_label=None,
            ip_country_status={"limited": [], "prohibited": ["KP", "SY", "IR"]},
            crypto_remediation_role_arn=None,
            default_profiles=["m6a.large", "m6a.xlarge"],
            application_questions=[
                {
                    "name": "why",
                    "question": "Why do you want access?",
                    "type": "text",
                    "rendering_options": "multi-line",
                    "placeholder": "Your Answer",
                }
            ],
            application_description=None,
            allows_tokens=False,
        ),
    },
    "lab_access": {
        "test_protected": {"can_user_see_lab": True, "can_user_access_lab": False},
    },
}
```

Labs that are protected will [always show up as keys in `lab_access`](https://github.com/ASFOpenSARlab/opensciencelab-portal-v2/blob/927fee24c7215277bfa042a4f18440a224c9f421/portal-cdk/lambda_main/objs/user/user.py#L207-L211), so `update` will always be `True` for non-private labs.

This fix handles this by actually interrogating whether a user has access to the lab (`can_user_access_lab`), which is part of the same dictionary.