### PR TITLE
[OSL-4441]Display user's email address on manage page

### DIFF
--- a/portal-cdk/lambda_main/templates/manage.j2
+++ b/portal-cdk/lambda_main/templates/manage.j2
@@ -125,6 +125,8 @@
             <tr>
                 <th>
                     <b><a href="/portal/profile/form/{{ user["username"] }}">{{ user["username"] }}</a></b>
+                    <br>
+                    <code>{{ user["email"] }}</code>
                 </th>
                 <th>
                     {% for profile in lab.allowed_profiles %}

--- a/portal-cdk/lambda_main/tests/portal/test_access.py
+++ b/portal-cdk/lambda_main/tests/portal/test_access.py
@@ -47,6 +47,7 @@ class TestAccessPages:
             return [
                 {
                     "username": "test_user",
+                    "email": "test@user.com",
                     "labs": {
                         "testlab": {
                             "lab_profiles": ["m6a.large"],
@@ -88,6 +89,7 @@ class TestAccessPages:
         assert ret["body"].find('value="m6a.large, m6a.xlarge"')
         assert ret["headers"].get("Content-Type") == "text/html"
         assert ret["body"].find("token-dne")
+        assert ret["body"].find("test@user.com")
 
         # Make sure tokens don't show up on lab w/o tokens
         event = helpers.get_event(
@@ -426,6 +428,7 @@ class TestAccessPages:
             return [
                 {
                     "username": "test_user",
+                    "email": "test@user.com",
                     "labs": {
                         "testlab": {
                             "lab_profiles": ["m6a.large"],
@@ -448,6 +451,7 @@ class TestAccessPages:
         assert body["users"] == [
             {
                 "username": "test_user",
+                "email": "test@user.com",
                 "labs": {"testlab": {"lab_profiles": ["m6a.large"]}},
             }
         ]


### PR DESCRIPTION
<img width="1482" height="739" alt="image" src="https://github.com/user-attachments/assets/30919731-ce81-4263-b8cd-d79ae39f056e" />
