### PR TITLE
[OSL-4440] Allow filtering by email when subset of users is displayed on lab manage page

### DIFF
--- a/portal-cdk/lambda_main/portal/access.py
+++ b/portal-cdk/lambda_main/portal/access.py
@@ -179,6 +179,9 @@ def manage_lab(shortname):
     template_input = {}
 
     user_filter = access_router.current_event.query_string_parameters.get("user_filter")
+    email_filter = access_router.current_event.query_string_parameters.get(
+        "email_filter"
+    )
     row_limit = 200
 
     # Get users of lab, check if lab exists
@@ -186,6 +189,7 @@ def manage_lab(shortname):
         shortname,
         limit=row_limit,
         username_filter=user_filter,
+        email_filter=email_filter,
     )
     users = sorted(users, key=lambda x: x["username"])
     template_input["users"] = users

--- a/portal-cdk/lambda_main/templates/manage.j2
+++ b/portal-cdk/lambda_main/templates/manage.j2
@@ -26,6 +26,8 @@
         <form action="/portal/access/manage/{{ lab.short_lab_name }}">
             Search results limited to {{ rowcount }}. Try filtering by username:
             <input type="input" name="user_filter">
+            Or by email:
+            <input type="input" name="email_filter">
             <input type="submit" hidden />
         </form>
     </div>


### PR DESCRIPTION
No new tests. email_filter behavior is validated [elsewhere](https://github.com/ASFOpenSARlab/opensciencelab-portal-v2/blob/ec2e9f2139d52ee1700ea920ae24629914735c58/portal-cdk/lambda_main/tests/portal/test_access.py#L546). 