### PR TITLE
fix: allow `next_url` to supersede `return_path`

### DIFF
--- a/portal-cdk/lambda_main/tests/util/test_auth.py
+++ b/portal-cdk/lambda_main/tests/util/test_auth.py
@@ -263,6 +263,22 @@ class TestPortalAuth:
         assert ret["headers"].get("Location").endswith("?return=/portal/hub")
         assert ret["headers"].get("Content-Type") == "text/html"
 
+    def test_next_url_overrides_return(self, lambda_context, helpers):
+        event = helpers.get_event(
+            path="/portal/hub/auth",
+            qparams={"next_url": "/lab/smce-prod-opensarlab/hub/home"},
+            cookies={"foo": "bar"},
+        )
+        ret = main.lambda_handler(event, lambda_context)
+        assert ret["statusCode"] == 302
+        assert ret["body"] == "User is not logged in"
+        assert (
+            ret["headers"]
+            .get("Location")
+            .endswith("?return=/lab/smce-prod-opensarlab/hub/home")
+        )
+        assert ret["headers"].get("Content-Type") == "text/html"
+
     def test_logged_in(self, lambda_context, fake_auth, helpers, monkeypatch):
         user = helpers.FakeUser()
         monkeypatch.setattr("portal.User", lambda *args, **kwargs: user)

--- a/portal-cdk/lambda_main/util/auth.py
+++ b/portal-cdk/lambda_main/util/auth.py
@@ -369,10 +369,20 @@ def require_access(access: list = ["user"], human: bool = False):
                 else:
                     cookies = []
 
+                redirect_location = f"/?return={return_path}"
+
+                next_location = (
+                    current_session.app.current_event.query_string_parameters.get(
+                        "next_url"
+                    )
+                )
+                if next_location is not None:
+                    redirect_location = f"/?return={next_location}"
+
                 return wrap_response(
                     body="User is not logged in",
                     code=302,
-                    headers={"Location": f"/?return={return_path}"},
+                    headers={"Location": redirect_location},
                     cookies=cookies,
                 )
 

--- a/portal-cdk/lambda_main/util/auth.py
+++ b/portal-cdk/lambda_main/util/auth.py
@@ -369,15 +369,16 @@ def require_access(access: list = ["user"], human: bool = False):
                 else:
                     cookies = []
 
-                redirect_location = f"/?return={return_path}"
-
                 next_location = (
                     current_session.app.current_event.query_string_parameters.get(
                         "next_url"
                     )
                 )
+
                 if next_location is not None:
                     redirect_location = f"/?return={next_location}"
+                else:
+                    redirect_location = f"/?return={return_path}"
 
                 return wrap_response(
                     body="User is not logged in",


### PR DESCRIPTION
Following the merge of https://github.com/ASFOpenSARlab/deployment-opensarlab-test-cluster/pull/160, a user gets redirected to the login page after their cookies expire/are deleted with only `?return=portal/hub/auth` in the URL, `?next=/lab/smce-test-opensarlab/hub/home` being dropped during the Cognito sign-in process, leading to user to be redirected to `portal/hub/auth` (which a user should never see).

This PR replaces the value of `?return` with `?next` if it exists at the login page redirect.

A working solution in my dev portal:

<img width="2322" height="1395" alt="cookie_reset_redirect_loop" src="https://github.com/user-attachments/assets/79704a27-0bdf-400b-9f91-8aa07023b5c4" />
