### PR TITLE
[OSL-4654 #3] add exporting users endpoint and button

### DIFF
--- a/portal-cdk/lambda_main/portal/access.py
+++ b/portal-cdk/lambda_main/portal/access.py
@@ -205,7 +205,11 @@ def export_users(shortname):
     writer.writerow(columns)
 
     for user in users:
-        values = [user["username"], user["labs"][shortname]["lab_profiles"], user["email"]]
+        values = [
+            user["username"],
+            user["labs"][shortname]["lab_profiles"],
+            user["email"]
+        ]
         if lab.allows_tokens:
             values.append([token["token"] for token in user["token_usage"]])
         writer.writerow(values)

--- a/portal-cdk/lambda_main/portal/access.py
+++ b/portal-cdk/lambda_main/portal/access.py
@@ -208,7 +208,7 @@ def export_users(shortname):
         values = [
             user["username"],
             user["labs"][shortname]["lab_profiles"],
-            user["email"]
+            user["email"],
         ]
         if lab.allows_tokens:
             values.append([token["token"] for token in user["token_usage"]])

--- a/portal-cdk/lambda_main/portal/access.py
+++ b/portal-cdk/lambda_main/portal/access.py
@@ -1,4 +1,6 @@
 import json
+import csv
+import io
 from dataclasses import asdict
 from datetime import datetime
 
@@ -183,6 +185,39 @@ def update_user_access_request(shortname, username):
         body={f"Redirect to {next_url}"},
         code=302,
         headers={"Location": next_url},
+    )
+
+
+@access_router.get("/manage/<shortname>/export-users", include_in_schema=False)
+@require_access(["admin", "lab_manager"], human=True)
+def export_users(shortname):
+    # Get lab info
+    lab = LAB_CONFIGS[shortname]
+
+    users = get_users_with_lab(shortname)
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+
+    # Write columns
+    columns = ["username", "profiles", "email"]
+    if lab.allows_tokens:
+        columns.append("token")
+    writer.writerow(columns)
+
+    for user in users:
+        values = [user["username"], user["labs"][shortname]["lab_profiles"], user["email"]]
+        if lab.allows_tokens:
+            values.append([token["token"] for token in user["token_usage"]])
+        writer.writerow(values)
+
+    return wrap_response(
+        body=buf.getvalue(),
+        code=200,
+        headers={
+            "Content-Type": "text/csv; charset=utf-8",
+            "Content-Disposition": 'attachment; filename="users.csv"',
+            "Cache-Control": "no-store",
+        },
     )
 
 

--- a/portal-cdk/lambda_main/templates/manage.j2
+++ b/portal-cdk/lambda_main/templates/manage.j2
@@ -125,12 +125,7 @@
     {% endif %}
 </div>
 <div class="margin-left-30">
-    <div style="display:flex; flex-direction: row; gap: 16px;">
-        <h3>Users</h3>
-        <div style="display:flex; justify-content:center; align-items: center; ">
-            <button style="height: 40%; transform: translateY(25%);" onclick="exportUsers()">Export</button>
-        </div>
-    </div>
+    <h3>Users</h3>
     <div class="margin-left-30">
         <div class="note">
             Notes on Management Interface
@@ -165,6 +160,7 @@
                 {% if lab.allows_tokens %}<th></th>{% endif %}
                 <th>
                     <button type="submit" name="action" value="add_user">Add</button>
+                    <button onclick="exportUsers()">Export All Users</button>
                 </th>
             </form>
         </tr>

--- a/portal-cdk/lambda_main/templates/manage.j2
+++ b/portal-cdk/lambda_main/templates/manage.j2
@@ -125,7 +125,12 @@
     {% endif %}
 </div>
 <div class="margin-left-30">
-    <h3>Users</h3>
+    <div style="display:flex; flex-direction: row; gap: 16px;">
+        <h3>Users</h3>
+        <div style="display:flex; justify-content:center; align-items: center; ">
+            <button style="height: 40%; transform: translateY(25%);" onclick="exportUsers()">Export</button>
+        </div>
+    </div>
     <div class="margin-left-30">
         <div class="note">
             Notes on Management Interface
@@ -284,4 +289,20 @@
         await fetchUsers();
         window.addEventListener('scroll', handleScroll);
     });
+    async function exportUsers(){
+        const res = await fetch('/portal/access/manage/{{ lab.short_lab_name }}/export-users', { method: 'GET' });
+        if(!res.ok) throw new Error("Failed to export users");
+        const cd = res.headers.get('Content-Disposition');
+
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = "users.csv";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+    };
 </script>

--- a/portal-cdk/lambda_main/tests/portal/test_access.py
+++ b/portal-cdk/lambda_main/tests/portal/test_access.py
@@ -1289,11 +1289,10 @@ class TestAccessPages:
         assert "></textarea>" in ret["body"]
         assert ret["body"].count("selected>") == 0
 
-    def test_lab_user_export(
-        self, monkeypatch, lambda_context, helpers, fake_auth
-    ):
+    def test_lab_user_export(self, monkeypatch, lambda_context, helpers, fake_auth):
         import csv
         import io
+
         # Checks permission required to access page
         user = helpers.FakeUser(access=["user", "lab_manager"])
         monkeypatch.setattr("portal.access.User", lambda *args, **kwargs: user)
@@ -1335,7 +1334,6 @@ class TestAccessPages:
         )
         ret = main.lambda_handler(event, lambda_context)
 
-
         assert ret["statusCode"] == 200
         assert ret["headers"].get("Content-Type") == "text/csv; charset=utf-8"
 
@@ -1343,7 +1341,12 @@ class TestAccessPages:
         f = io.StringIO(ret["body"])
         reader = csv.reader(f)
         columns = next(reader, None)
-        assert columns == ['username', 'profiles', 'email', 'token']
+        assert columns == ["username", "profiles", "email", "token"]
 
         data_row = next(reader, None)
-        assert data_row == ['test_user', "['m6a.large']", 'test@user.com', "['token-dne']"]
+        assert data_row == [
+            "test_user",
+            "['m6a.large']",
+            "test@user.com",
+            "['token-dne']",
+        ]

--- a/portal-cdk/lambda_main/tests/portal/test_access.py
+++ b/portal-cdk/lambda_main/tests/portal/test_access.py
@@ -1288,3 +1288,62 @@ class TestAccessPages:
         assert ret["statusCode"] == 200
         assert "></textarea>" in ret["body"]
         assert ret["body"].count("selected>") == 0
+
+    def test_lab_user_export(
+        self, monkeypatch, lambda_context, helpers, fake_auth
+    ):
+        import csv
+        import io
+        # Checks permission required to access page
+        user = helpers.FakeUser(access=["user", "lab_manager"])
+        monkeypatch.setattr("portal.access.User", lambda *args, **kwargs: user)
+        monkeypatch.setattr("util.auth.User", lambda *args, **kwargs: user)
+
+        labs = helpers.FAKE_LAB_CONFIGS
+        monkeypatch.setattr("portal.access.LAB_CONFIGS", labs)
+        lab = helpers.FakeLab(managers=[user.username])
+        monkeypatch.setattr(
+            "portal.access.Lab",
+            lambda *args, **kwargs: lab,
+        )
+        monkeypatch.setattr("util.auth.Lab", lambda *args, **kwargs: lab)
+
+        def lab_users_static(*args, **kwargs):
+            return [
+                {
+                    "username": "test_user",
+                    "email": "test@user.com",
+                    "labs": {
+                        "testlab": {
+                            "lab_profiles": ["m6a.large"],
+                        },
+                    },
+                    "token_usage": [
+                        {
+                            "labname": "testlab",
+                            "token": "token-dne",
+                            "apply_date": datetime.now().strftime(DATE_F),
+                        }
+                    ],
+                }
+            ]
+
+        monkeypatch.setattr("portal.access.get_users_with_lab", lab_users_static)
+
+        event = helpers.get_event(
+            path="/portal/access/manage/testlab/export-users", cookies=fake_auth
+        )
+        ret = main.lambda_handler(event, lambda_context)
+
+
+        assert ret["statusCode"] == 200
+        assert ret["headers"].get("Content-Type") == "text/csv; charset=utf-8"
+
+        # Test CSV is properly formatted
+        f = io.StringIO(ret["body"])
+        reader = csv.reader(f)
+        columns = next(reader, None)
+        assert columns == ['username', 'profiles', 'email', 'token']
+
+        data_row = next(reader, None)
+        assert data_row == ['test_user', "['m6a.large']", 'test@user.com', "['token-dne']"]


### PR DESCRIPTION
Adds an endpoint that returns a csv file of all users in the lab.
Adds an export button on the lab manager page that downloads the csv to `users.csv`

<img width="3160" height="1266" alt="image" src="https://github.com/user-attachments/assets/77902a3f-dc02-4d67-b730-165b74cc5415" />
