### PR TITLE
Add GEOS631 lab for geos cluster v2

### DIFF
--- a/.github/workflows/on-pull-cdk-diff.yaml
+++ b/.github/workflows/on-pull-cdk-diff.yaml
@@ -8,7 +8,7 @@ on: # yamllint disable-line rule:truthy
       - main
 
 permissions:
-   contents: read
+  contents: read
 
 jobs:
 

--- a/labs.py
+++ b/labs.py
@@ -1,0 +1,1 @@
+portal-cdk/lambda_main/util/labs/__init__.py

--- a/portal-cdk/lambda_main/util/labs/__init__.py
+++ b/portal-cdk/lambda_main/util/labs/__init__.py
@@ -206,7 +206,7 @@ PROD_LAB_CONFIGS = {
         <p>Placeholder for GEOS 631/636</p>
         """,
         deployment_url="http://eks-cluster-geos-368fe5a0d3301df1.elb.us-west-2.amazonaws.com",
-        accessibility="protected",
+        accessibility="private",
         allowed_profiles=[
             "GEOS 631",
             "GEOS 631 - Debug",
@@ -224,7 +224,7 @@ NON_PROD_LAB_CONFIGS = {
         <p>Placeholder for GEOS 631/636</p>
         """,
         deployment_url="http://eks-cluster-geos-368fe5a0d3301df1.elb.us-west-2.amazonaws.com",
-        accessibility="protected",
+        accessibility="private",
         allowed_profiles=[
             "GEOS 631",
             "GEOS 631 - Debug",

--- a/portal-cdk/lambda_main/util/labs/__init__.py
+++ b/portal-cdk/lambda_main/util/labs/__init__.py
@@ -199,9 +199,39 @@ PROD_LAB_CONFIGS = {
         default_profiles=["m6a.large", "m6a.xlarge"],
         allows_tokens=True,
     ),
+    "geos": BaseLabConfig(
+        short_lab_name="geos",
+        friendly_name="GEOS 631/636",
+        description="""
+        <p>Placeholder for GEOS 631/636</p>
+        """,
+        deployment_url="http://eks-cluster-geos-368fe5a0d3301df1.elb.us-west-2.amazonaws.com",
+        accessibility="protected",
+        allowed_profiles=[
+            "GEOS 631",
+            "GEOS 631 - Debug",
+            "sudo",
+        ],
+        default_profiles=["GEOS 631"],
+    ),
 }
 
 NON_PROD_LAB_CONFIGS = {
+    "geos": BaseLabConfig(
+        short_lab_name="geos",
+        friendly_name="GEOS 631/636",
+        description="""
+        <p>Placeholder for GEOS 631/636</p>
+        """,
+        deployment_url="http://eks-cluster-geos-368fe5a0d3301df1.elb.us-west-2.amazonaws.com",
+        accessibility="protected",
+        allowed_profiles=[
+            "GEOS 631",
+            "GEOS 631 - Debug",
+            "sudo",
+        ],
+        default_profiles=["GEOS 631"],
+    ),
     "test": BaseLabConfig(
         short_lab_name="test",
         friendly_name="Cluster v2 - test",


### PR DESCRIPTION
Also added a symlink at the repo root called `labs.py` that link to `portal-cdk/lambda_main/util/labs/__init__.py` where all the labs are defined.